### PR TITLE
Pass correct number of args

### DIFF
--- a/src/cljs/salttoday/views/comment.cljs
+++ b/src/cljs/salttoday/views/comment.cljs
@@ -18,7 +18,7 @@
 (defn component-content [state]
   (list [:div.column.justify-center.comments-wrapper
          (for [comment (:comments @state)]
-           (comment-component comment))]))
+           (comment-component comment false))]))
 
 ; Helpful Docs - https://purelyfunctional.tv/guide/reagent/#form-2
 (defn comment-page [query-params]


### PR DESCRIPTION
Gets rid of dumb warning when running lein figwheel etc.