### PR TITLE
Mark comments as not being deleted when storing comments

### DIFF
--- a/src/clj/salttoday/db/comments.clj
+++ b/src/clj/salttoday/db/comments.clj
@@ -68,12 +68,14 @@
                               :comment/text text
                               :comment/time timestamp
                               :comment/upvotes upvotes
-                              :comment/downvotes downvotes}
+                              :comment/downvotes downvotes
+                              :comment/deleted false}
                              {:db/id post-id
                               :post/comment "comment"}])
       (tx-with-logging conn [{:db/id comment-id
                               :comment/upvotes upvotes
-                              :comment/downvotes downvotes}]))
+                              :comment/downvotes downvotes
+                              :comment/deleted false}]))
     (tx-with-logging conn [{:db/id user-id
                             :user/upvotes (+ user-upvotes upvote-increase)
                             :user/downvotes (+ user-downvotes downvote-increase)}])


### PR DESCRIPTION
Sometimes comments are marked as deleted, but we find them later meaning that they still exist.
To resolve this, anytime a comment is updated in the db, mark it as not deleted.

Fixes https://github.com/salt-today/salttoday/issues/121