### PR TITLE
Default to user's all time comments on user page instead of that days

### DIFF
--- a/src/cljs/salttoday/components/comment.cljs
+++ b/src/cljs/salttoday/components/comment.cljs
@@ -94,7 +94,7 @@
       ; Empty Offset
       [:div.column.comment-author {:style {:flex 70}}
        [:a.author-link {:on-click (fn [] (do
-                                           (swap! state assoc :user (:user comment))
+                                           (swap! state assoc :user (:user comment) :days "0")
                                            (update-query-params-with-state state :comments :users)
                                            (get-comments state)))} "- "
         (:user comment)]]

--- a/src/cljs/salttoday/views/users.cljs
+++ b/src/cljs/salttoday/views/users.cljs
@@ -35,7 +35,7 @@
   [:div.row
    [:div.row.user-name-row
     [:span
-     [:a {:on-click (fn [] (accountant/navigate! (str "/home?user=" (:name user))))}
+     [:a {:on-click (fn [] (accountant/navigate! (str "/home?user=" (:name user) "&days=" 0)))}
       (:name user)]]]
    [:div.row.user-stats-row
     [:span.positive


### PR DESCRIPTION
User pages were defaulting to just showing their comments for that day which often leads to no visible comments. Default to showing their top comments from all time.
Fixes https://github.com/salt-today/salttoday/issues/123