### PR TITLE
Add caching to comments

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
                  [metosin/muuntaja "0.5.0"]
                  [metosin/ring-http-response "0.9.1"]
                  [mount "0.1.16"]
+                 [org.clojure/core.memoize "1.0.236"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/tools.logging "0.5.0-alpha.1"]
                  [overtone/at-at "1.2.0"]

--- a/src/clj/salttoday/core.clj
+++ b/src/clj/salttoday/core.clj
@@ -56,4 +56,5 @@
         minutes (* seconds 60)
         interval (* 15 minutes)
         pool (at-at/mk-pool)]
-    (at-at/every interval #(update-posts-and-comments (scrape-sootoday)) pool)))
+    (at-at/every interval #(update-posts-and-comments (scrape-sootoday)) pool)
+    (at-at/every interval #(salttoday.db.comments/refresh-memoization) pool)))

--- a/src/clj/salttoday/core.clj
+++ b/src/clj/salttoday/core.clj
@@ -1,5 +1,6 @@
 (ns salttoday.core
   (:require [salttoday.routes.handler :as handler]
+            [salttoday.db.comments :refer [refresh-memoization]]
             [salttoday.db.posts :refer [update-posts-and-comments]]
             [salttoday.scraper.core :refer [scrape-sootoday]]
             [overtone.at-at :as at-at]
@@ -57,4 +58,4 @@
         interval (* 15 minutes)
         pool (at-at/mk-pool)]
     (at-at/every interval #(update-posts-and-comments (scrape-sootoday)) pool)
-    (at-at/every interval #(salttoday.db.comments/refresh-memoization) pool)))
+    (at-at/every interval #(refresh-memoization) pool)))

--- a/src/clj/salttoday/db/comments.clj
+++ b/src/clj/salttoday/db/comments.clj
@@ -174,3 +174,17 @@
   ; TODO - get rid of the usage in statistics.clj
   ([db]
    (get-comments db 0 1 nil -1 nil nil nil false)))
+
+(def memoized-get-comments
+  (let [seconds 1000
+        minutes (* seconds 60)
+        interval (* 15 minutes)]
+    (clojure.core.memoize/ttl get-comments :ttl/threshold interval)))
+
+(defn refresh-memoization []
+  (log/info "Refreshing comments cache")
+  (memoized-get-comments 0 20 :score 1 nil nil 0 false)
+  (memoized-get-comments 0 20 :score 7 nil nil 0 false)
+  (memoized-get-comments 0 20 :score 30 nil nil 0 false)
+  (memoized-get-comments 0 20 :score 365 nil nil 0 false)
+  (memoized-get-comments 0 20 :score 0 nil nil 0 false))

--- a/src/clj/salttoday/db/comments.clj
+++ b/src/clj/salttoday/db/comments.clj
@@ -1,5 +1,6 @@
 (ns salttoday.db.comments
   (:require [datomic.api :as d]
+            [clojure.core.memoize :as memoize]
             [clojure.set :as set]
             [salttoday.db.util :refer [remap-query sort-by-specified get-date paginate-results tx-with-logging]]
             [salttoday.db.connection :refer [conn]]
@@ -179,7 +180,7 @@
   (let [seconds 1000
         minutes (* seconds 60)
         interval (* 15 minutes)]
-    (clojure.core.memoize/ttl get-comments :ttl/threshold interval)))
+    (memoize/ttl get-comments :ttl/threshold interval)))
 
 (defn refresh-memoization []
   (log/info "Refreshing comments cache")

--- a/src/clj/salttoday/routes/api/v1/controller.clj
+++ b/src/clj/salttoday/routes/api/v1/controller.clj
@@ -1,5 +1,5 @@
 (ns salttoday.routes.api.v1.controller
-  (:require [salttoday.db.comments :refer [get-comments]]
+  (:require [salttoday.db.comments :refer [memoized-get-comments]]
             [salttoday.db.users :refer [get-users]]
             [salttoday.routes.util :as routing-util]
             [ring.util.response :as response]
@@ -20,7 +20,7 @@
         id-num (routing-util/string->number id)
         deleted-bool (routing-util/string->bool deleted)
         user-str (routing-util/blank-str->nil user)   ; convert to nil if string is blank
-        results (get-comments offset-num amount-num (keyword sort-type) days-num search-text user-str id-num deleted-bool)]
+        results (memoized-get-comments offset-num amount-num (keyword sort-type) days-num search-text user-str id-num deleted-bool)]
     (-> (http-response/ok results)
         (response/header "Content-Type"
                          "application/json"))))


### PR DESCRIPTION
Site can be a little slow, especially when doing the first query to datomic. Add a cache for some of the most common calls to the `get-comments` func, and refresh this every 15 minutes (how often we scrape comments)